### PR TITLE
ヘッダーのjs導入

### DIFF
--- a/app/assets/javascripts/header.js
+++ b/app/assets/javascripts/header.js
@@ -1,17 +1,58 @@
 $(function(){
-  // $('.product-form__input').on('keyup', function(e){
-  //   var input = $('.product-form__input').val();
-  //   console.log(input);
-  //   e.preventDefault();
-  //   var formData = new FormData(this);
-  // })
-  // $('.pc-header-box-lower__left-parent-wrap').find('ul').hide();
-  // $('.pc-header-box-lower__left li').hover(function(){
-  // $(this).find('ul').show();
-  // // console.log(input);
-  // // e.preventDefault();
-  // },
-  // function(){  
-  // $(this).find('ul').hide();
-  // })
+  $('.pc-header-box-lower__left-parent-wrap').hide();
+ 
+
+  $('.pc-header-box-lower__left li').hover(function(){
+    $('h2 a span',this).css('color','blue');
+    $('ul',this).show();
+    $('ul li ul',this).hide();
+    },
+    function(){
+      $('h2 a span',this).css('color','black');
+      $('ul',this).hide();
+  })
+
+
+  $('.pc-header-box-lower__left-parent').hover(function(){
+    $('.pc-header-box-lower__left li h2 a span').css({"color": ""});
+    $(this).css('background', 'red');
+    $(this).children().css('color','white');
+  },function(){
+    $(this).css('background', '');
+    $(this).children().css('color', '');
+  })
+
+  
+  $('.pc-header-box-lower__left-children').hover(function(){
+    $(this).css('background', 'lightgray');
+    $('.pc-header-box-lower__left-grand-children').hover(function(){
+      $(this).css('background', 'lightgray');
+  },function(){
+    $(this).css('background', '');
+  })
+  },function(){
+    $(this).css('background', '');
+  })
+
+
+  $('.pc-header-box-lower__left-brand').hover(function(){
+    $(this).css('color','blue');
+    $(this).css('background', 'red');
+    $(this).children().css('color','white');
+  },function(){
+    $(this).css('background', '');
+    $(this).children().css('color', '');
+  })
+  
+  
+  $('.pc-header-box-lower__right .login-box').hover(function(){
+    $(this).children().css('color','white');
+    $(this).css('background','blue');
+
+  },function(){
+    $(this).css('background', '');
+    $(this).children().css('color', '');
+  })
+
+
 })

--- a/app/assets/javascripts/header.js
+++ b/app/assets/javascripts/header.js
@@ -5,25 +5,13 @@ $(function(){
   //   e.preventDefault();
   //   var formData = new FormData(this);
   // })
-  $('.pc-header-box-lower__left-parent-wrap').find('ul').hide();
-  $('.pc-header-box-lower__left li').hover(function(){
-  $(this).find('ul').show();
-  // console.log(input);
-  // e.preventDefault();
-  },
-  function(){  
-  $(this).find('ul').hide();
-  })
-
-  $('.pc-header-box-lower__left li').find('ul').hide();
-  $('.pc-header-box-lower__left li').hover(function(){
-  $(this).find('ul').show();
-  // console.log(input);
-  // e.preventDefault();
-  },
-  function(){
-  
-  $(this).find('ul li').hide();
-  })
-
+  // $('.pc-header-box-lower__left-parent-wrap').find('ul').hide();
+  // $('.pc-header-box-lower__left li').hover(function(){
+  // $(this).find('ul').show();
+  // // console.log(input);
+  // // e.preventDefault();
+  // },
+  // function(){  
+  // $(this).find('ul').hide();
+  // })
 })

--- a/app/assets/stylesheets/modules/_product.scss
+++ b/app/assets/stylesheets/modules/_product.scss
@@ -65,13 +65,29 @@
               color: red;
             }
           }
-          ul {
+          .pc-header-box-lower__left-parent-wrap {
+            position: absolute;
             height: 50px;
             width: 160px;
             border: solid;
-            // li {
-            //   width: 224px;
-            // }
+            z-index: 100;
+            // display: none;
+            .pc-header-box-lower__left-parent li{
+              width: 224px;
+              border: solid;
+              .pc-header-box-lower__left-child-wrap ul{
+                position: absolute;
+                top: 0;
+                left: 224px;
+                bottom: 0;
+                .pc-header-box-lower__left-children{
+                  display: none;
+                  .pc-header-box-lower__left-grand-child-wrap{
+                    
+                  }
+                }
+              }
+            }
           }
         }
       }

--- a/app/assets/stylesheets/modules/_product.scss
+++ b/app/assets/stylesheets/modules/_product.scss
@@ -2,6 +2,12 @@
   text-decoration: none;
 }
 
+a{
+  color: black;
+}
+h3{
+  color: black;
+}
 .pc-header{
   width: 100%;
   height: 100px;
@@ -16,20 +22,17 @@
         float:right;
         position: relative;
         .product-form__input{
-          // position: relative;
           height: 40px;
           width: 840px;
           font-size: 16px;
           border-radius: 4px;
           padding: 0 42px 0 10px;
-          // margin-left: 45px;
           border: 1px solid #ccc;
           box-sizing: border-box;
           float: left;
         }
         &__search{
           position: absolute;
-          // float: left;
           top: 0;
           right:0;
           width: 40px;
@@ -39,54 +42,107 @@
           justify-content: center;
           align-items: center;
           background-color: gray;
-            color: white;
+          color: white;
         }
       }
     }
     .pc-header-box-lower{
       margin:8px 0 0;
-      width: 1020px;
-      height:40px;
-      display: inherit;
+      width: 1004px;
+      height:42px;
+      display: block;
       &__left{
+        position: relative;
         width:400px;
         height:inherit;
         float:left;
+        padding:8px 0 0 0;
         li{
-          padding:0 5px;
           display: inline-block;
           height: inherit;
           width: 160px;
-          // padding: 10px;
           font-size: inherit;
           h2 {
-            font-size: inherit;
+            width: inherit;
+            height: inherit;
+            position: relative;
+            padding: 0; 
+            .list-parent{
+              display: block;
+            }
+            .list-brand{
+              display: block;
+            }
             .fa{
               color: red;
             }
           }
+        }
           .pc-header-box-lower__left-parent-wrap {
             position: absolute;
-            height: 50px;
-            width: 160px;
-            border: solid;
+            top: 42px;
+            left: 0;
+            height: 400px;
+            width: 224px;
             z-index: 100;
-            // display: none;
-            .pc-header-box-lower__left-parent li{
+            background-color: #ffffff;
+            .pc-header-box-lower__left-parent{
               width: 224px;
-              border: solid;
-              .pc-header-box-lower__left-child-wrap ul{
-                position: absolute;
-                top: 0;
-                left: 224px;
-                bottom: 0;
-                .pc-header-box-lower__left-children{
-                  display: none;
-                  .pc-header-box-lower__left-grand-child-wrap{
-                    
-                  }
-                }
+              height: 40px;
+              float: left;
+              line-height: 42px;
+              a{
+                display: block;
               }
+            }
+            
+          .pc-header-box-lower__left-child-wrap{
+            background-color: #ffffff;
+            width: 224px;
+            height: 400px;
+            position: absolute;
+            top: 0;
+            left: 224px;
+            display: inline-block;
+            .pc-header-box-lower__left-children{
+              width: 224px;
+              height: 30px;
+              display: block;
+              line-height: 30px;
+            }
+          }
+          
+          .pc-header-box-lower__left-grand-child-wrap{
+            background-color: #ffffff;
+            width: 224px;
+            height: 400px;
+            position: absolute;
+            top: 0;
+            left: 224px;
+            display: inline-block;
+            .pc-header-box-lower__left-grand-children{
+              width: 224px;
+              height: 30px;
+
+            }
+          }
+        }
+        .pc-header-box-lower__left-brand-wrap {
+          position: absolute;
+          top: 42px;
+          left: 160px;
+          height: 400px;
+          width: 224px;
+          z-index: 100;
+          background-color: #ffffff;
+          display: none;
+          .pc-header-box-lower__left-brand{
+            width: 224px;
+            height: 40px;
+            float: left;
+            line-height: 42px;
+            a{
+              display: block;
             }
           }
         }
@@ -96,14 +152,14 @@
         height:38px;
         float:right;
         position: relative;
-      }
+
       ul{
         height:38px;
         width:260px;
         margin:0;
         padding:0;
-        p:first-child{
-          margin:0;
+        li:first-child{
+          // margin:0;
           height:35px;
           // width:106px;
           width: auto;
@@ -122,23 +178,24 @@
             text-align: center;
           }
         }
-        p{
+      }
+        li{
           margin:0;
           height:35px;
-          // width:106px;
-          width: auto;
+          width: 78px;
           float:left;
           padding: 0 10px;
           margin: 0 5px;
           display: flex;
           justify-content: center;
           align-items: center;
-          // background-color: red;
           border-radius: 4px;
           border:1px solid blue; 
-        .sp-header-btn.header-login{
-          color: blue;
-          text-decoration:none;
+          .sp-header-btn.header-login{
+            color: blue;
+            text-decoration:none;
+            display: block;
+            text-align: center;
           }
         }
       }

--- a/app/views/items/index.html.haml
+++ b/app/views/items/index.html.haml
@@ -16,12 +16,14 @@
               %i
                 = fa_icon "list-ul"
               %span カテゴリーから探す
-          -# %ul.pc-header-box-lower__left-parent-wrap
-          -#   %h3
-          -#     非同期
-          -#   %li.pc-header-box-lower__left-parent
-          -#     %h3
-          -#       実装中
+          %ul.pc-header-box-lower__left-parent-wrap
+            %li.pc-header-box-lower__left-parent
+              %h3
+                実装中
+                %ul.pc-header-box-lower__left-child-wrap
+                  %li.pc-header-box-lower__left-children
+                    %ul.pc-header-box-lower__left-grand-child-wrap
+                      %li.pc-header-box-lower__left-grand-children
 
         %li
           %h2

--- a/app/views/items/index.html.haml
+++ b/app/views/items/index.html.haml
@@ -12,31 +12,113 @@
       .pc-header-box-lower__left
         %li
           %h2
-            %a{href: "https://www.mercari.com/jp/category/", class: "pc-header-lower list-parent"}
+            %a{href: "https://www.mercari.com/jp/category/", class: "pc-header-lower__left list-parent"}
               %i
                 = fa_icon "list-ul"
               %span カテゴリーから探す
           %ul.pc-header-box-lower__left-parent-wrap
             %li.pc-header-box-lower__left-parent
-              %h3
-                実装中
-                %ul.pc-header-box-lower__left-child-wrap
-                  %li.pc-header-box-lower__left-children
-                    %ul.pc-header-box-lower__left-grand-child-wrap
-                      %li.pc-header-box-lower__left-grand-children
+              %a
+                レディース
+              %ul.pc-header-box-lower__left-child-wrap
+                %li.pc-header-box-lower__left-children
+                  %a
+                    トップス
+                  %ul.pc-header-box-lower__left-grand-child-wrap
+                    %li.pc-header-box-lower__left-grand-children
+                      %a
+                        Tシャツ/カットソー(半袖/袖なし)
+                    %li.pc-header-box-lower__left-grand-children
+                      %a
+                        Tシャツ/カットソー(七分/長袖)
+
+                %li.pc-header-box-lower__left-children
+                  %a
+                    ジャケット/アウター
+                  %ul.pc-header-box-lower__left-grand-child-wrap
+                    %li.pc-header-box-lower__left-grand-children
+                      %a
+                        Tシャツ/カットソー(七分/長袖)
+                    %li.pc-header-box-lower__left-grand-children
+                      %a
+                        ノーカラージャケット
+
+
+            %li.pc-header-box-lower__left-parent
+              %a
+                メンズ
+              %ul.pc-header-box-lower__left-child-wrap
+                %li.pc-header-box-lower__left-children
+                  %a
+                    トップス
+                  %ul.pc-header-box-lower__left-grand-child-wrap
+                    %li.pc-header-box-lower__left-grand-children
+                      %a
+                        Tシャツ/カットソー(半袖/袖なし)
+                    %li.pc-header-box-lower__left-grand-children
+                      %a
+                        Tシャツ/カットソー(七分/長袖)
+
+                %li.pc-header-box-lower__left-children
+                  %a
+                    ジャケット/アウター
+                  %ul.pc-header-box-lower__left-grand-child-wrap
+                    %li.pc-header-box-lower__left-grand-children
+                      %a
+                        Tシャツ/カットソー(七分/長袖)
+                    %li.pc-header-box-lower__left-grand-children
+                      %a
+                        ノーカラージャケット
+
+            %li.pc-header-box-lower__left-parent
+              %a
+                ベビー・キッズ
+              %ul.pc-header-box-lower__left-child-wrap
+                %li.pc-header-box-lower__left-children
+                  %a
+                    ベビー服(女の子用)~95cm
+                  %ul.pc-header-box-lower__left-grand-child-wrap
+                    %li.pc-header-box-lower__left-grand-children
+                      %a
+                        トップス
+                    %li.pc-header-box-lower__left-grand-children
+                      %a
+                        アウター
+
+                %li.pc-header-box-lower__left-children
+                  %a
+                    ベビー服(男の子用)~95cm
+                  %ul.pc-header-box-lower__left-grand-child-wrap
+                    %li.pc-header-box-lower__left-grand-children
+                      %a
+                        トップス
+                    %li.pc-header-box-lower__left-grand-children
+                      %a
+                        アウター
+
+
+
+
 
         %li
           %h2
-            %a{href: "https://www.mercari.com/jp/category/", class: "pc-header-lower list-parent"}
-            %i
-              = fa_icon "tag"
-            %span ブランドから探す
+            %a{href: "https://www.mercari.com/jp/category/", class: "pc-header-lower list-brand"}
+              %i
+                = fa_icon "tag"
+              %span ブランドから探す
+          %ul.pc-header-box-lower__left-brand-wrap
+            %li.pc-header-box-lower__left-brand
+              %a
+                シャネル
+
+
+
 
       .pc-header-box-lower__right
         %ul.pc-header-box-lower__right-login-nav
-          %p.signup-box
+          %li.signup-box
             %a{href: "https://www.mercari.com/jp/signup/", class: "sp-header-btn header-signup"}新規会員登録
-          %p.login-box
+          %li.login-box
             %a{href: "https://www.mercari.com/jp/login/?login_callback=https%3A%2F%2Fwww.mercari.com%2Fjp%2F", class: "sp-header-btn header-login"}ログイン
           
 = render partial: 'main'

--- a/app/views/products/index.html.haml
+++ b/app/views/products/index.html.haml
@@ -1,0 +1,39 @@
+.pc-header
+  .pc-header-box
+    .pc-header-box-upper
+      %a
+        %img{src:"https://www-mercari-jp.akamaized.net/assets/img/common/common/logo.svg?2921618501", alt: "mercari_icon", width:"134", height: "36"}/
+      .pc-header-box-upper__field--right
+        %input.product-form__input{placeholder: "何かお探しですか？", type: "text"}/
+        %i.pc-header-box-upper__field--right__search
+          = fa_icon "search"
+
+    .pc-header-box-lower
+      .pc-header-box-lower__left
+        %li
+          %h2
+            %a{href: "https://www.mercari.com/jp/category/", class: "pc-header-lower list-parent"}
+              %i
+                = fa_icon "list-ul"
+              %span カテゴリーから探す
+          -# %ul.pc-header-box-lower__left-parent-wrap
+          -#   %h3
+          -#     非同期
+          -#   %li.pc-header-box-lower__left-parent
+          -#     %h3
+          -#       実装中
+
+        %li
+          %h2
+            %a{href: "https://www.mercari.com/jp/category/", class: "pc-header-lower list-parent"}
+            %i
+              = fa_icon "tag"
+            %span ブランドから探す
+
+      .pc-header-box-lower__right
+        %ul.pc-header-box-lower__right-login-nav
+          %p.signup-box
+            %a{href: "https://www.mercari.com/jp/signup/", class: "sp-header-btn header-signup"}新規会員登録
+          %p.login-box
+            %a{href: "https://www.mercari.com/jp/login/?login_callback=https%3A%2F%2Fwww.mercari.com%2Fjp%2F", class: "sp-header-btn header-login"}ログイン
+          


### PR DESCRIPTION
# WHAT
　ヘッダーの「カテゴリーから探す」、「ブランドから探す」にマウスオーバーした時にメニューリストが開くようにした。
　
　現在マウスで洗濯している項目の背景に色がつくようにした。
　
　ログインボタンにマウスオーバーした時にボタンが青く表示されるようにした。

# WHY
　ユーザーが現在選択している項目を視覚的にわかりやすくするため。

　使いやすさを考え、検索ページを経由することなく、直感的に目的の商品にたどり着けるようにするため。


　なおメニューリストに表示される項目は全項目とはしておりません。全項目表示となると14×14×14となるので一部抜粋に留めています。