### PR TITLE
購入機能について修正

### DIFF
--- a/app/controllers/creditcards_controller.rb
+++ b/app/controllers/creditcards_controller.rb
@@ -57,13 +57,16 @@ class CreditcardsController < ApplicationController
       redirect_to action: "new"
     else
       Payjp.api_key = ENV['PAYJP_PRIVATE_KEY']
-      Payjp::Charge.create(
-      amount: item.price, #支払金額を入力（itemテーブル等に紐づけても良い）
-      customer: card.customer_id, #顧客ID
-      currency: 'jpy', #日本円
-    )
-      item.update(buyer_id: current_user.id)
-      redirect_to root_path, notice: "支払いが完了しました"
+      customer = Payjp::Customer.retrieve(card.customer_id)
+      unless customer.id != card.customer_id
+        Payjp::Charge.create(
+        amount: item.price, #支払金額を入力（itemテーブル等に紐づけても良い）
+        customer: card.customer_id, #顧客ID
+        currency: 'jpy', #日本円
+      )
+        item.update(buyer_id: current_user.id)
+        redirect_to root_path, notice: "支払いが完了しました"
+      end
     end
 
   end

--- a/app/controllers/creditcards_controller.rb
+++ b/app/controllers/creditcards_controller.rb
@@ -53,12 +53,12 @@ class CreditcardsController < ApplicationController
   def buy
     item = Item.find(params[:id])
     card = Creditcard.where(user_id: current_user.id).first
-    if card.blank?
-      redirect_to action: "new"
-    else
-      Payjp.api_key = ENV['PAYJP_PRIVATE_KEY']
-      customer = Payjp::Customer.retrieve(card.customer_id)
-      unless customer.id != card.customer_id
+    unless current_user.id == item.seller_id
+      if card.blank?
+        redirect_to action: "new"
+      else
+        Payjp.api_key = ENV['PAYJP_PRIVATE_KEY']
+        customer = Payjp::Customer.retrieve(card.customer_id)       
         Payjp::Charge.create(
         amount: item.price, #支払金額を入力（itemテーブル等に紐づけても良い）
         customer: card.customer_id, #顧客ID
@@ -67,6 +67,8 @@ class CreditcardsController < ApplicationController
         item.update(buyer_id: current_user.id)
         redirect_to root_path, notice: "支払いが完了しました"
       end
+    else
+      redirect_to root_path, notice: "自分の商品は購入できません"
     end
 
   end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -102,7 +102,7 @@ class ItemsController < ApplicationController
   def purchase
     @item = Item.find(params[:id])
     card = Creditcard.where(user_id: current_user.id).first
-    if @item.seller_id == current_user.id
+    if @item.seller_id == current_user.id || @item.buyer_id != nil
       redirect_to item_path(params[:id])
     else
       if card.blank?

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -102,12 +102,16 @@ class ItemsController < ApplicationController
   def purchase
     @item = Item.find(params[:id])
     card = Creditcard.where(user_id: current_user.id).first
-    if card.blank?
-      redirect_to new_creditcard_path
+    if @item.seller_id == current_user.id
+      redirect_to item_path(params[:id])
     else
-      Payjp.api_key = ENV["PAYJP_PRIVATE_KEY"]
-      customer = Payjp::Customer.retrieve(card.customer_id)
-      @default_card_information = customer.cards.retrieve(card.card_id)
+      if card.blank?
+        redirect_to new_creditcard_path
+      else
+        Payjp.api_key = ENV["PAYJP_PRIVATE_KEY"]
+        customer = Payjp::Customer.retrieve(card.customer_id)
+        @default_card_information = customer.cards.retrieve(card.card_id)
+      end
     end
   end
 

--- a/app/views/items/purchase.html.haml
+++ b/app/views/items/purchase.html.haml
@@ -4,7 +4,7 @@
   .item_header
     .item_header_icon
       = link_to 'https://www.mercari.com/jp/' do
-        = image_tag '/assets/mercari-logos/top-logo.svg',class:"mercari_icon"
+        = image_tag 'http://u0u0.net/QHiY',width:'180px',class:"mercari_icon"
 
 
 .buy-all-container__box
@@ -15,12 +15,13 @@
         .buy-content__box--inner
           %h3.buy-content__box--inner-image
             = image_tag @item.images.first.image.url,class:"buy-content-photo"
-          %p.buy-content__box--inner-name ナイキの新作スニーカー 新品 美品
-
+          %p.buy-content__box--inner-name
+            = @item.name
           .buy-form-box
             %p.buy-content__price-ja.bold
               ￥#{@item.price}
-              %span.buy-content__fee 送料込み
+              %span.buy-content__fee
+                = @item.deliveryfee
             %ul.buy-content-accordion-box.not-have
               %li.buy-content-accordion-parent
                 .buy-content-accordion-box-toggle.not-have ポイントはありません


### PR DESCRIPTION
# WHAT
商品確認画面の商品名が固定のものになっている
商品購入確認画面のヘッダー画像が無い
自身が出品した商品の商品購入確認画面へ飛べる
自身が出品した商品の購入ができる

# WHY
毎回購入される商品変わるので、商品名それぞれに合わせないといけない
よくない
自分のもの購入できないように制限が必要